### PR TITLE
update: Moved code divs within figure containers on INDEX

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,6 @@ Finding your way around
             </div>
             <div class="example-boxes" id="example-bg-img-grad-lefttoright-3col"></div>
           </figure>
-
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
             <div class="content-box-code">
@@ -191,70 +190,72 @@ Finding your way around
           <div class="content-box-text">
             <p>For more control of the direction of the gradient an angle can be set instead of the directions</p>
           </div>
-          <div class="content-box-code">
-            <code><span class="code-box-comment">/*direction set as angle 0deg which is same as bottom to top*/</span><br>
-              div { <br>
-              background-image: linear-gradient(0deg, color1, color2, color3, color4, color5);<br>
-              }</code>
-          </div>
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*direction set as angle 0deg which is same as bottom to top*/</span><br>
+                div { <br>
+                background-image: linear-gradient(0deg, color1, color2, color3, color4, color5);<br>
+                }</code>
+            </div>
             <div class="example-boxes" id=""></div>
           </figure>
-          <div class="content-box-code">
-            <code><span class="code-box-comment">/*direction set as angle 90deg which is same as left to right*/</span><br>
-              div { <br>
-              background-image: linear-gradient(90deg, color1, color2, color3, color4, color5, color6);<br>
-              }</code>
-          </div>
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*direction set as angle 90deg which is same as left to right*/</span><br>
+                div { <br>
+                background-image: linear-gradient(90deg, color1, color2, color3, color4, color5, color6);<br>
+                }</code>
+            </div>
             <div class="example-boxes" id=""></div>
           </figure>
-          <div class="content-box-code">
-            <code><span class="code-box-comment">/*direction set as angle 180deg which is same as top to bottom*/</span><br>
-              div { <br>
-              background-image: linear-gradient(180deg, color1, color2, color3, color4, color5, color6, color7);<br>
-              }</code>
-          </div>
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*direction set as angle 180deg which is same as top to bottom*/</span><br>
+                div { <br>
+                background-image: linear-gradient(180deg, color1, color2, color3, color4, color5, color6, color7);<br>
+                }</code>
+            </div>
             <div class="example-boxes" id=""></div>
           </figure>
           <div class="content-box-text">
             <p>This allows more exact diagonal lines to be used...</p>
           </div>
-          <div class="content-box-code">
-            <code><span class="code-box-comment">/*direction set as angle 125deg */</span><br>
-              div { <br>
-              background-image: linear-gradient(125deg, color1, color2, color3);<br>
-              }</code>
-          </div>
+
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*direction set as angle 125deg */</span><br>
+                div { <br>
+                background-image: linear-gradient(125deg, color1, color2, color3);<br>
+                }</code>
+            </div>
             <div class="example-boxes" id=""></div>
           </figure>
-          <div class="content-box-code">
-            <code><span class="code-box-comment">/*direction set as angle 270deg */</span><br>
-              div { <br>
-              background-image: linear-gradient(270deg, color1, color2, color3);<br>
-              }</code>
-          </div>
+
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*direction set as angle 270deg */</span><br>
+                div { <br>
+                background-image: linear-gradient(270deg, color1, color2, color3);<br>
+                }</code>
+            </div>
             <div class="example-boxes" id=""></div>
           </figure>
           <div class="content-box-text">
             <p>The gradient can also be set to repeat itself...</p>
           </div>
-          <div class="content-box-code">
-            <code><span class="code-box-comment">/*2 color gradient set to repeat*/</span><br>
-              div { <br>
-              background-image: repeating-linear-gradient(0deg, color1, color2);<br>
-              }</code>
-          </div>
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*2 color gradient set to repeat*/</span><br>
+                div { <br>
+                background-image: repeating-linear-gradient(0deg, color1, color2);<br>
+                }</code>
+            </div>
             <div class="example-boxes" id=""></div>
           </figure>
           <div class="content-box-text">
@@ -271,24 +272,26 @@ Finding your way around
               <li>Circle</li>
             </ol>
           </div>
-          <div class="content-box-code">
-            <code><span class="code-box-comment">/*3 color elliptical radial gradient*/</span><br>
-              div { <br>
-              background-image: radial-gradient(red, yellow, green);<br>
-              }</code>
-          </div>
+
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*3 color elliptical radial gradient*/</span><br>
+                div { <br>
+                background-image: radial-gradient(red, yellow, green);<br>
+                }</code>
+            </div>
             <div class="example-boxes" id=""></div>
           </figure>
-          <div class="content-box-code">
-            <code><span class="code-box-comment">/*2 color gradient set to repeat*/</span><br>
-              div { <br>
-              background-image: repeating-radial-gradient(color1, color2);<br>
-              }</code>
-          </div>
+
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*2 color gradient set to repeat*/</span><br>
+                div { <br>
+                background-image: repeating-radial-gradient(color1, color2);<br>
+                }</code>
+            </div>
             <div class="example-boxes" id=""></div>
           </figure>
           <div class="content-box-text">
@@ -301,68 +304,74 @@ Finding your way around
               <li>farthest-corner</li>
             </ul>
           </div>
-          <div class="content-box-code">
-            <code><span class="code-box-comment">/*3 color radial gradient using closest-side size*/</span><br>
-              div { <br>
-              background-image: radial-gradient(closest-side at 70% 25%, color1, color2, color3);<br>
-              }</code>
-          </div>
+
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*3 color radial gradient using closest-side size*/</span><br>
+                div { <br>
+                background-image: radial-gradient(closest-side at 70% 25%, color1, color2, color3);<br>
+                }</code>
+            </div>
             <div class="example-boxes" id=""></div>
           </figure>
-          <div class="content-box-code">
-            <code><span class="code-box-comment">/*3 color radial gradient using farthest-side size*/</span><br>
-              div { <br>
-              background-image: radial-gradient(farthest-side at 70% 25%, color1, color2, color3);<br>
-              }</code>
-          </div>
+
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*3 color radial gradient using farthest-side size*/</span><br>
+                div { <br>
+                background-image: radial-gradient(farthest-side at 70% 25%, color1, color2, color3);<br>
+                }</code>
+            </div>
             <div class="example-boxes" id=""></div>
           </figure>
-          <div class="content-box-code">
-            <code><span class="code-box-comment">/*3 color radial gradient using closest-corner size*/</span><br>
-              div { <br>
-              background-image: radial-gradient(closest-corner at 70% 25%, color1, color2, color3);<br>
-              }</code>
-          </div>
+
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*3 color radial gradient using closest-corner size*/</span><br>
+                div { <br>
+                background-image: radial-gradient(closest-corner at 70% 25%, color1, color2, color3);<br>
+                }</code>
+            </div>
             <div class="example-boxes" id=""></div>
           </figure>
-          <div class="content-box-code">
-            <code><span class="code-box-comment">/*3 color radial gradient using farthest-corner size*/</span><br>
-              div { <br>
-              background-image: radial-gradient(farthest-corner at 70% 25%, color1, color2, color3);<br>
-              }</code>
-          </div>
+
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*3 color radial gradient using farthest-corner size*/</span><br>
+                div { <br>
+                background-image: radial-gradient(farthest-corner at 70% 25%, color1, color2, color3);<br>
+                }</code>
+            </div>
             <div class="example-boxes" id=""></div>
           </figure>
           <div class="content-box-text">
             <p class="mini-header">Colour stops</p>
             <p>For both linear and radial gradients you can also specify how much of the gradient is in each colour instead of all using an equal fraction....</p>
           </div>
-          <div class="content-box-code">
-            <code><span class="code-box-comment">/*3 color circular linear gradient*/</span><br>
-              div { <br>
-              background-image: linear-gradient(to right, color1 25%, color2 50%, color3);<br>
-              }</code>
-          </div>
+
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*3 color circular linear gradient*/</span><br>
+                div { <br>
+                background-image: linear-gradient(to right, color1 25%, color2 50%, color3);<br>
+                }</code>
+            </div>
             <div class="example-boxes" id=""></div>
           </figure>
-          <div class="content-box-code">
-            <code><span class="code-box-comment">/*3 color circular radial gradient*/</span><br>
-              div { <br>
-              background-image: repeating-linear-gradient(color1 20%, color2 15%, color3);<br>
-              }</code>
-          </div>
+
           <figure class="content-box-code-example">
             <figcaption>Insert example box</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*3 color circular radial gradient*/</span><br>
+                div { <br>
+                background-image: repeating-linear-gradient(color1 20%, color2 15%, color3);<br>
+                }</code>
+            </div>
             <div class="example-boxes" id=""></div>
           </figure>
         </div>
@@ -420,17 +429,18 @@ Finding your way around
             }
           </code>
         </div>
-        <div class="content-box-code">
-          <code><span class="code-box-comment">/*background top and center*/</span><br>
-            div { <br>
-            background-image: url(https://imagehosting/image.png);<br>
-            background-repeat: no-repeat;<br>
-            background-position: top center;<br>
-            }
-          </code>
-        </div>
+
         <figure class="content-box-code-example">
           <figcaption>Insert example box</figcaption>
+          <div class="content-box-code">
+            <code><span class="code-box-comment">/*background top and center*/</span><br>
+              div { <br>
+              background-image: url(https://imagehosting/image.png);<br>
+              background-repeat: no-repeat;<br>
+              background-position: top center;<br>
+              }
+            </code>
+          </div>
           <div class="example-boxes" id=""></div>
         </figure>
       </div>

--- a/style.css
+++ b/style.css
@@ -161,8 +161,8 @@ section .content-box-text {
 
 section .content-box-code code {
   display: inline-block;
-  margin-left: 1em;
-  padding: 0.3em 0;
+  margin: 0 0.5em;
+  padding: 0.3em;
 }
 
 section .content-box-code code .code-box-comment {
@@ -281,7 +281,7 @@ Code example figure boxes
 
 #example-bg-img-grad-intro {
   background-color: var(--dark-colour);
-   background-image: linear-gradient(to bottom, orange, blue, white);
+  background-image: linear-gradient(to bottom, orange, blue, white);
 }
 
 /*2 colour gradient from top to bottom */
@@ -302,6 +302,7 @@ Code example figure boxes
     var(--lightest-colour)
   );
 }
+
 /*====
 Footer
 =======*/


### PR DESCRIPTION
Moved code snip container div to within figure to make it easier to style to compliment the code example boxes when there is one