### PR TITLE
update: change figcaption set on example boxes in INDEX

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,7 @@ Finding your way around
             </ol>
           </div>
           <figure class="content-box-code-example">
-            <figcaption>2 colour linear gradient</figcaption>
+            <figcaption>Up and Down</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*direction set using default of top to bottom*/</span><br>
                 div { <br>
@@ -168,7 +168,7 @@ Finding your way around
             <div class="example-boxes" id="example-bg-img-grad-top-bottom-2col"></div>
           </figure>
           <figure class="content-box-code-example">
-            <figcaption>3 colour linear gradient</figcaption>
+            <figcaption>Side to Side</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*direction set from left to right*/</span><br>
                 div { <br>
@@ -178,7 +178,7 @@ Finding your way around
             <div class="example-boxes" id="example-bg-img-grad-lefttoright-3col"></div>
           </figure>
           <figure class="content-box-code-example">
-            <figcaption>4 colour diagonal linear gradient</figcaption>
+            <figcaption>Diagonally</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*direction set diagonally*/</span><br>
                 div { <br>
@@ -191,7 +191,7 @@ Finding your way around
             <p>For more control of the direction of the gradient an angle can be set instead of the directions</p>
           </div>
           <figure class="content-box-code-example">
-            <figcaption>5 colour linear gradient</figcaption>
+            <figcaption>Top by degrees</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*direction set as angle 0deg which is same as bottom to top*/</span><br>
                 div { <br>
@@ -201,7 +201,7 @@ Finding your way around
             <div class="example-boxes" id="example-bg-img-grad-0deg-5col"></div>
           </figure>
           <figure class="content-box-code-example">
-            <figcaption>6 colour linear gradient</figcaption>
+            <figcaption>Sideways degrees</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*direction set as angle 90deg which is same as left to right*/</span><br>
                 div { <br>
@@ -211,7 +211,7 @@ Finding your way around
             <div class="example-boxes" id="example-bg-img-grad-90deg-6col"></div>
           </figure>
           <figure class="content-box-code-example">
-            <figcaption>7 colour linear gradient</figcaption>
+            <figcaption>Bottom degree</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*direction set as angle 180deg which is same as top to bottom*/</span><br>
                 div { <br>
@@ -224,7 +224,7 @@ Finding your way around
             <p>This allows more exact diagonal lines to be used...</p>
           </div>
           <figure class="content-box-code-example">
-            <figcaption>3 colour diagonal gradient</figcaption>
+            <figcaption>Diagonal degree</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*direction set as angle 125deg */</span><br>
                 div { <br>
@@ -235,7 +235,7 @@ Finding your way around
           </figure>
 
           <figure class="content-box-code-example">
-            <figcaption>3 colour diagonal gradient</figcaption>
+            <figcaption>Diagonal gradient</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*direction set as angle 270deg */</span><br>
                 div { <br>
@@ -248,7 +248,7 @@ Finding your way around
             <p>The gradient can also be set to repeat itself...</p>
           </div>
           <figure class="content-box-code-example">
-            <figcaption>Repeating linear gradient</figcaption>
+            <figcaption>Linear repeating</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*Color gradient set to repeat*/</span><br>
                 div { <br>
@@ -274,7 +274,7 @@ Finding your way around
           </div>
 
           <figure class="content-box-code-example">
-            <figcaption>3 colour elliptical radial gradient</figcaption>
+            <figcaption>Radial Ellipsis</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*3 color elliptical radial gradient*/</span><br>
                 div { <br>
@@ -285,7 +285,7 @@ Finding your way around
           </figure>
 
           <figure class="content-box-code-example">
-            <figcaption>3 colour circular radial gradient</figcaption>
+            <figcaption>Radial circle</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*3 color circular radial gradient*/</span><br>
                 div { <br>
@@ -296,7 +296,7 @@ Finding your way around
           </figure>
 
           <figure class="content-box-code-example">
-            <figcaption>Repeating radial gradient</figcaption>
+            <figcaption>Radial repeating</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*color gradient set to repeat*/</span><br>
                 div { <br>
@@ -316,7 +316,7 @@ Finding your way around
             </ul>
           </div>
           <figure class="content-box-code-example">
-            <figcaption>Radial gradiant</figcaption>
+            <figcaption>Closest-Side Radial</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*3 color radial gradient using closest-side size*/</span><br>
                 div { <br>
@@ -326,47 +326,77 @@ Finding your way around
             <div class="example-boxes" id="example-bg-img-grad-rad-closest-side"></div>
           </figure>
           <figure class="content-box-code-example">
-            <figcaption>Radial gradiant</figcaption>
+            <figcaption>Closest-Side Degree</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*3 color radial gradient using closest-side size set by degree*/</span><br>
                 div { <br>
-                background-image: radial-gradient(circel closest-side at 70% 25%, color1, color2, color3);<br>
+                background-image: radial-gradient(circle closest-side at 70% 25%, color1, color2, color3);<br>
                 }</code>
             </div>
             <div class="example-boxes" id="example-bg-img-grad-rad-closest-side-deg"></div>
           </figure>
 
           <figure class="content-box-code-example">
-            <figcaption>Insert example box</figcaption>
+            <figcaption>Farthest-Side Radial</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*3 color radial gradient using farthest-side size*/</span><br>
                 div { <br>
-                background-image: radial-gradient(farthest-side at 70% 25%, color1, color2, color3);<br>
+                background-image: radial-gradient(circle farthest-side, color1, color2, color3);<br>
                 }</code>
             </div>
             <div class="example-boxes" id="example-bg-img-grad-rad-farthest-side"></div>
           </figure>
-
           <figure class="content-box-code-example">
-            <figcaption>Insert example box</figcaption>
+            <figcaption>Farthest-Side Degree</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*3 color radial gradient using farthest-side size set by degree*/</span><br>
+                div { <br>
+                background-image: radial-gradient(circle farthest-side at 25% 50%, color1, color2, color3);<br>
+                }</code>
+            </div>
+            <div class="example-boxes" id="example-bg-img-grad-rad-farthest-side-deg"></div>
+          </figure>
+          <figure class="content-box-code-example">
+            <figcaption>Closest-corner Radial</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*3 color radial gradient using closest-corner size*/</span><br>
                 div { <br>
-                background-image: radial-gradient(closest-corner at 70% 25%, color1, color2, color3);<br>
+                background-image: radial-gradient(circle closest-corner, color1, color2, color3);<br>
                 }</code>
             </div>
-            <div class="example-boxes" id=""></div>
+            <div class="example-boxes" id="example-bg-img-grad-rad-closest-corner"></div>
           </figure>
 
           <figure class="content-box-code-example">
-            <figcaption>Insert example box</figcaption>
+            <figcaption>Closest-corner Radial</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*3 color radial gradient using closest-corner size set by degree*/</span><br>
+                div { <br>
+                background-image: radial-gradient(circle closest-corner at 70% 25%, color1, color2, color3);<br>
+                }</code>
+            </div>
+            <div class="example-boxes" id="example-bg-img-grad-rad-closest-corner-deg"></div>
+          </figure>
+
+          <figure class="content-box-code-example">
+            <figcaption>Farthest-corner Radial</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*3 color radial gradient using farthest-corner size*/</span><br>
                 div { <br>
-                background-image: radial-gradient(farthest-corner at 70% 25%, color1, color2, color3);<br>
+                background-image: radial-gradient(circel farthest-corner, color1, color2, color3);<br>
                 }</code>
             </div>
-            <div class="example-boxes" id=""></div>
+            <div class="example-boxes" id="example-bg-img-grad-rad-farthest-corner"></div>
+          </figure>
+          <figure class="content-box-code-example">
+            <figcaption>Farthest-corner degrees</figcaption>
+            <div class="content-box-code">
+              <code><span class="code-box-comment">/*3 color radial gradient using farthest-corner size set by degree*/</span><br>
+                div { <br>
+                background-image: radial-gradient(circle farthest-corner at 50% 25%, color1, color2, color3);<br>
+                }</code>
+            </div>
+            <div class="example-boxes" id="example-bg-img-grad-rad-farthest-corner-deg"></div>
           </figure>
           <div class="content-box-text">
             <p class="mini-header">Colour stops</p>
@@ -374,7 +404,7 @@ Finding your way around
           </div>
 
           <figure class="content-box-code-example">
-            <figcaption>Insert example box</figcaption>
+            <figcaption>Linear colour stops</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*3 color circular linear gradient*/</span><br>
                 div { <br>
@@ -385,7 +415,7 @@ Finding your way around
           </figure>
 
           <figure class="content-box-code-example">
-            <figcaption>Insert example box</figcaption>
+            <figcaption>Radial colour stops</figcaption>
             <div class="content-box-code">
               <code><span class="code-box-comment">/*3 color circular radial gradient*/</span><br>
                 div { <br>


### PR DESCRIPTION
Changed the figcaption from general sub-heading to be more relevant for each example box but still short enough to use single line on small mobile screen views . For Example changed "Radial Gradient" to " Farthest-corner degree"